### PR TITLE
Switch to use passport-strategy instead of pinning to a specific version of passport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+package-lock.json

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -1,7 +1,7 @@
 /**
  * Module dependencies.
  */
-var passport = require('passport');
+var Strategy = require('passport-strategy');
 var crypto   = require('crypto');
 var util     = require('util');
 
@@ -26,7 +26,7 @@ function HerokuAddonStrategy(options) {
 
   if (!options || !options.sso_salt) throw new Error('Passport Heroku Addon strategy requires a sso_salt');
 
-  passport.Strategy.call(this);
+  Strategy.call(this);
   this.name = 'heroku-addon';
   this._sso_salt = options.sso_salt;
   this._passReqToCallback = options.passReqToCallback;
@@ -35,7 +35,7 @@ function HerokuAddonStrategy(options) {
 /**
  * Inherit from `passport.Strategy`.
  */
-util.inherits(HerokuAddonStrategy, passport.Strategy);
+util.inherits(HerokuAddonStrategy, Strategy);
 
 /**
  * Authenticate request based on id and timestamp params.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
   "main": "lib/strategy.js",
   "license": "MIT",
   "dependencies": {
-    "passport": "~0.1.17"
+    "passport-strategy": "1.x.x"
   }
 }


### PR DESCRIPTION
### Description
Switching to use https://github.com/jaredhanson/passport-strategy instead of https://github.com/jaredhanson/passport for inheriting the Strategy function class. This avoid issues with `package-lock.json` when combined with other strategies of passport that rely on different versions of the main one.

Given the diff https://github.com/auth0/passport/commit/0e233c0e25cb0d1565ab426a2a68254b0b9131d5 and the contents of the `passport-strategy` module, changes are non-breaking.

